### PR TITLE
Add double/float support for Convert

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
@@ -387,6 +387,10 @@ void Symbol::saveXmlHeader(ostream &s) const
       s << "oct\"";
     else if (format == force_bin)
       s << "bin\"";
+    else if (format == force_float)
+      s << "float\"";
+    else if (format == force_float)
+      s << "double\"";
     else
       s << "hex\"";
   }
@@ -425,6 +429,10 @@ void Symbol::restoreXmlHeader(const Element *el)
 	    dispflags |= force_oct;
 	  else if (formString == "bin")
 	    dispflags |= force_bin;
+      else if (formString == "float")
+        dispflags |= force_float;
+      else if (formString == "double")
+        dispflags |= force_double;
 	}
 	break;
       case 'h':

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.hh
@@ -181,6 +181,8 @@ public:
     force_oct = 3,		///< Force octal printing of constant symbol
     force_bin = 4,		///< Force binary printing of constant symbol
     force_char = 5,		///< Force integer to be printed as a character constant
+    force_float = 6,    ///< Force float to be printed as a character constant
+    force_double = 7,   ///< Force double to be printed as a character constant
     size_typelock = 8,	        ///< Only the size of the symbol is typelocked
     isolate = 16,		///< Symbol should not speculatively merge automatically
     merge_problems = 32,	///< Set if some SymbolEntrys did not get merged

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -15,7 +15,6 @@
  */
 #include "printc.hh"
 #include "funcdata.hh"
-
 // Operator tokens for expressions
 //                        token #in prec assoc   optype       space bump
 OpToken PrintC::hidden = { "", 1, 70, false, OpToken::hiddenfunction, 0, 0, (OpToken *)0 };
@@ -1133,7 +1132,17 @@ void PrintC::push_integer(uintb val,int4 sz,bool sign,
     t << hex << "0x" << val;
   else if (displayFormat == Symbol::force_dec)
     t << dec << val;
-  else if (displayFormat == Symbol::force_oct)
+  else if (displayFormat == Symbol::force_float) {
+    const FloatFormat *format = glb->translate->getFloatFormat(sizeof(val));
+    FloatFormat::floatclass type;
+    double floatval = format->getHostFloat(val,&type);
+    t << std::setprecision(7) << floatval;
+  }else if (displayFormat == Symbol::force_double) {
+    const FloatFormat *format = glb->translate->getFloatFormat(sizeof(val));
+    FloatFormat::floatclass type;
+    double doubleval = format->getHostFloat(val,&type);
+    t << std::setprecision(16) << doubleval;
+  }else if (displayFormat == Symbol::force_oct)
     t << oct << '0' << val;
   else if (displayFormat == Symbol::force_char) {
     int4 internalSize = 4;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -15,6 +15,7 @@
  */
 #include "printc.hh"
 #include "funcdata.hh"
+#include <iomanip>
 // Operator tokens for expressions
 //                        token #in prec assoc   optype       space bump
 OpToken PrintC::hidden = { "", 1, 70, false, OpToken::hiddenfunction, 0, 0, (OpToken *)0 };
@@ -1136,12 +1137,13 @@ void PrintC::push_integer(uintb val,int4 sz,bool sign,
     const FloatFormat *format = glb->translate->getFloatFormat(sizeof(val));
     FloatFormat::floatclass type;
     double floatval = format->getHostFloat(val,&type);
-    t << std::setprecision(7) << floatval;
+
+    t << showpoint << std::setprecision(7) << floatval;
   }else if (displayFormat == Symbol::force_double) {
     const FloatFormat *format = glb->translate->getFloatFormat(sizeof(val));
     FloatFormat::floatclass type;
     double doubleval = format->getHostFloat(val,&type);
-    t << std::setprecision(16) << doubleval;
+    t << showpoint << std::setprecision(16) << doubleval;
   }else if (displayFormat == Symbol::force_oct)
     t << oct << '0' << val;
   else if (displayFormat == Symbol::force_char) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/floatformat/FloatFormat.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/floatformat/FloatFormat.java
@@ -87,12 +87,12 @@ public strictfp class FloatFormat {
 			displayContext = new MathContext(7, RoundingMode.HALF_EVEN);
 		}
 		else if (size == 4) {
-			signbit_pos = 31;
-			exp_pos = 23;
-			exp_size = 8;
+			signbit_pos = 63;
+			exp_pos = 52;
+			exp_size = 11;
 			frac_pos = 0;
-			frac_size = 23;
-			bias = 127;
+			frac_size = 52;
+			bias = 1023;
 			jbitimplied = true;
 			displayContext = new MathContext(7, RoundingMode.HALF_EVEN);
 		}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/EquateSymbol.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/EquateSymbol.java
@@ -17,10 +17,11 @@ package ghidra.program.model.pcode;
 
 import ghidra.program.model.address.Address;
 import ghidra.program.model.data.DataType;
-import ghidra.util.Msg;
 import ghidra.util.xml.SpecXmlUtils;
 import ghidra.xml.XmlElement;
 import ghidra.xml.XmlPullParser;
+import ghidra.pcode.floatformat.*;
+import java.math.BigInteger;
 
 public class EquateSymbol extends HighSymbol {
 
@@ -30,6 +31,8 @@ public class EquateSymbol extends HighSymbol {
 	public static final int FORMAT_OCT = 3;
 	public static final int FORMAT_BIN = 4;
 	public static final int FORMAT_CHAR = 5;
+	public static final int FORMAT_FLOAT = 6;
+	public static final int FORMAT_DOUBLE = 7;
 
 	private long value;			// Value of the equate
 	private int convert;		// Non-zero if this is a conversion equate
@@ -115,6 +118,10 @@ public class EquateSymbol extends HighSymbol {
 			}
 			else if (convert == FORMAT_CHAR) {
 				formString = "char";
+			}else if (convert == FORMAT_FLOAT) {
+				formString = "float";
+			}else if (convert == FORMAT_DOUBLE) {
+				formString = "double";
 			}
 			SpecXmlUtils.encodeStringAttribute(buf, "format", formString);
 		}
@@ -136,9 +143,14 @@ public class EquateSymbol extends HighSymbol {
 				return FORMAT_DEFAULT;			// Bad equate name, just print number normally
 			}
 		}else if (nm.contains("-")) {        //Characteristics of the current double type
-			Msg.showWarn(EquateSymbol.class, null, "Conversion Not Implemented",
-					"Currently decompiler does not support Double or Float type to convert");
-			return FORMAT_DEC;
+			int DoubleSize = 8;				//The double type does not have the problem of loss of precision, so it is used as a comparison method here
+			FloatFormat format = FloatFormatFactory.getFloatFormat(DoubleSize);
+			String doubleFormat = format.round(format.getHostFloat(new BigInteger(String.valueOf(val)))).toString();
+			if (doubleFormat.equals(nm)) {
+				return FORMAT_DOUBLE;
+			}else{
+				return FORMAT_FLOAT;
+			}
 		}
 		if (firstChar == '\'') {
 			return FORMAT_CHAR;


### PR DESCRIPTION
This pr mainly solves the problem that Convert does not support double/float types #7 .
The solution is to add support for double/float types in the cpp layer of the decompiler.
Figure showing effect:

![image](https://user-images.githubusercontent.com/82093214/119705312-2bd45780-be8b-11eb-918f-94299272ff70.png)

- [x]  add double/float support for Convert 
- [x]  Fix the accuracy error of float type in java layer
- [x]  Fix the accuracy error of double/float type in cpp layer
- [x]   Fix the fixe-length filling problem of double/floating-point decimals in cpp layer