### PR TITLE
IDA-like default variable names in decompiler

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.cc
@@ -1358,6 +1358,7 @@ void Architecture::resetDefaultsInternal(void)
   infer_pointers = true;
   analyze_for_loops = true;
   readonlypropagate = false;
+  short_var_names = false;
   alias_block_level = 2;	// Block structs and arrays by default
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.hh
@@ -133,6 +133,7 @@ public:
   bool readonlypropagate;	///< true if readonly values should be treated as constants
   bool infer_pointers;		///< True if we should infer pointers from constants that are likely addresses
   bool analyze_for_loops;	///< True if we should attempt conversion of \e whiledo loops to \e for loops
+  bool short_var_names; ///< True if we should use less verbose default variable names
   vector<AddrSpace *> inferPtrSpaces;	///< Set of address spaces in which a pointer constant is inferable
   int4 funcptr_align;		///< How many bits of alignment a function ptr has
   uint4 flowoptions;            ///< options passed to flow following engine

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.hh
@@ -729,7 +729,6 @@ class ScopeInternal : public Scope {
   void processHole(const Element *el);
   void processCollision(const Element *el);
   void insertNameTree(Symbol *sym);
-  SymbolNameTree::const_iterator findFirstByName(const string &name) const;
 protected:
   virtual Scope *buildSubScope(uint8 id,const string &nm);	///< Build an unattached Scope to be associated as a sub-scope of \b this
   virtual void addSymbolInternal(Symbol *sym);
@@ -791,6 +790,7 @@ public:
   virtual int4 getCategorySize(int4 cat) const;
   virtual Symbol *getCategorySymbol(int4 cat,int4 ind) const;
   virtual void setCategory(Symbol *sym,int4 cat,int4 ind);
+  virtual SymbolNameTree::const_iterator findFirstByName(const string &name) const;
   void assignDefaultNames(int4 &base);		///< Assign a default name (via buildVariableName) to any unnamed symbol
   set<Symbol *>::const_iterator beginMultiEntry(void) const { return multiEntrySet.begin(); }	///< Start of symbols with more than one entry
   set<Symbol *>::const_iterator endMultiEntry(void) const { return multiEntrySet.end(); }	///< End of symbols with more than one entry

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/options.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/options.cc
@@ -58,6 +58,7 @@ OptionDatabase::OptionDatabase(Architecture *g)
   registerOption(new OptionDefaultPrototype());
   registerOption(new OptionInferConstPtr());
   registerOption(new OptionForLoops());
+  registerOption(new OptionShortVars());
   registerOption(new OptionInline());
   registerOption(new OptionNoReturn());
   registerOption(new OptionStructAlign());
@@ -261,6 +262,19 @@ string OptionForLoops::apply(Architecture *glb,const string &p1,const string &p2
   glb->analyze_for_loops = onOrOff(p1);
 
   string res = "Recovery of for-loops is " + p1;
+  return res;
+}
+
+/// \class OptionShortVars
+/// \brief Toggle whether the decompiler attempts to use shorter variable names
+///
+/// Setting the first parameter to "on" causes the decompiler to use shorter variables names
+string OptionShortVars::apply(Architecture *glb,const string &p1,const string &p2,const string &p3) const
+
+{
+  glb->short_var_names = onOrOff(p1);
+
+  string res = "Short var names is " + p1;
   return res;
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/options.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/options.hh
@@ -102,6 +102,12 @@ public:
   virtual string apply(Architecture *glb,const string &p1,const string &p2,const string &p3) const;
 };
 
+class OptionShortVars : public ArchOption {
+public:
+  OptionShortVars(void) { name = "shortvarnames"; }	///< Constructor
+  virtual string apply(Architecture *glb,const string &p1,const string &p2,const string &p3) const;
+};
+
 class OptionInline : public ArchOption {
 public:
   OptionInline(void) { name = "inline"; }	///< Constructor

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
@@ -410,25 +410,47 @@ string ScopeLocal::buildVariableName(const Address &addr,
 				     Datatype *ct,
 				     int4 &index,uint4 flags) const
 {
+  bool shortname = glb->short_var_name;
   if (((flags & (Varnode::addrtied|Varnode::persist))==Varnode::addrtied) &&
       addr.getSpace() == space) {
     if (fd->getFuncProto().getLocalRange().inRange(addr,1)) {
       intb start = (intb) AddrSpace::byteToAddress(addr.getOffset(),space->getWordSize());
       sign_extend(start,addr.getAddrSize()*8-1);
       if (stackGrowsNegative)
-	start = -start;
+	      start = -start;
       ostringstream s;
-      if (ct != (Datatype *)0)
-	ct->printNameBase(s);
+      if(shortname)
+      {
+        string spacename = addr.getSpace()->getName();
+        s << spacename[0] << index++;
+        if (start <= 0) {
+	        s << 'X';		// Indicate local stack space allocated by caller
+	        start = -start;
+        }
+        if (findFirstByName(s.str()) != nametree.end()) {	// If the name already exists
+          for(int4 i=0;i<10;++i) {	// Try bumping up the index a few times before calling makeNameUnique
+	        ostringstream s2;
+	          s2 << spacename[0] << dec << index++;
+	          if (findFirstByName(s2.str()) == nametree.end()) {
+              return s2.str();
+            }
+          }
+        }
+        return makeNameUnique(s.str());
+      }
+      else{
+        if (ct != (Datatype *)0)
+	        ct->printNameBase(s);
       string spacename = addr.getSpace()->getName();
       spacename[0] = toupper(spacename[0]);
       s << spacename;
       if (start <= 0) {
-	s << 'X';		// Indicate local stack space allocated by caller
-	start = -start;
+	      s << 'X';		// Indicate local stack space allocated by caller
+      	start = -start;
       }
       s << dec << start;
       return makeNameUnique(s.str());
+      }
     }
   }
   return ScopeInternal::buildVariableName(addr,pc,ct,index,flags);

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileOptions.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileOptions.java
@@ -94,6 +94,12 @@ public class DecompileOptions {
 	private final static boolean ANALYZEFORLOOPS_OPTIONDEFAULT = true;	// Must match Architecture::resetDefaultsInternal
 	private boolean analyzeForLoops;
 
+	private final static String SHORTVARNAMES_OPTIONSTRING = "Analysis.Short variable names";
+	private final static String SHORTVARNAMES_OPTIONDESCRIPTION = 
+		"If set, the decompiler attempts to use shorter default variable names";
+	private final static boolean SHORTVARNAMES_OPTIONDEFAULT = false; // Must match Architecture::resetDefaultsInternal
+	private boolean shortVarNames;
+
 	private final static String NULLTOKEN_OPTIONSTRING = "Display.Print 'NULL' for null pointers";
 	private final static String NULLTOKEN_OPTIONDESCRIPTION =
 		"If set, any zero valued pointer (null pointer) will " +
@@ -377,6 +383,7 @@ public class DecompileOptions {
 		ignoreunimpl = IGNOREUNIMPL_OPTIONDEFAULT;
 		inferconstptr = INFERCONSTPTR_OPTIONDEFAULT;
 		analyzeForLoops = ANALYZEFORLOOPS_OPTIONDEFAULT;
+		shortVarNames = SHORTVARNAMES_OPTIONDEFAULT;
 		nullToken = NULLTOKEN_OPTIONDEFAULT;
 		inplaceTokens = INPLACEOP_OPTIONDEFAULT;
 		aliasBlock = ALIASBLOCK_OPTIONDEFAULT;
@@ -440,6 +447,8 @@ public class DecompileOptions {
 		inferconstptr = opt.getBoolean(INFERCONSTPTR_OPTIONSTRING, INFERCONSTPTR_OPTIONDEFAULT);
 		analyzeForLoops =
 			opt.getBoolean(ANALYZEFORLOOPS_OPTIONSTRING, ANALYZEFORLOOPS_OPTIONDEFAULT);
+		shortVarNames =
+			opt.getBoolean(SHORTVARNAMES_OPTIONSTRING, SHORTVARNAMES_OPTIONDEFAULT);
 		nullToken = opt.getBoolean(NULLTOKEN_OPTIONSTRING, NULLTOKEN_OPTIONDEFAULT);
 		inplaceTokens = opt.getBoolean(INPLACEOP_OPTIONSTRING, INPLACEOP_OPTIONDEFAULT);
 		aliasBlock = opt.getEnum(ALIASBLOCK_OPTIONSTRING, ALIASBLOCK_OPTIONDEFAULT);
@@ -724,6 +733,9 @@ public class DecompileOptions {
 		}
 		if (analyzeForLoops != ANALYZEFORLOOPS_OPTIONDEFAULT) {
 			appendOption(buf, "analyzeforloops", analyzeForLoops ? "on" : "off", "", "");
+		}
+		if (shortVarNames != SHORTVARNAMES_OPTIONDEFAULT) {
+			appendOption(buf, "shortvarnames", shortVarNames ? "on" : "off", "", "");
 		}
 		if (nullToken != NULLTOKEN_OPTIONDEFAULT) {
 			appendOption(buf, "nullprinting", nullToken ? "on" : "off", "", "");


### PR DESCRIPTION
### Introduction

Due to the variable name of ghidra's decompilation is too long, we made some modifications, the following is an example
before
![image](https://user-images.githubusercontent.com/44017204/125443981-f35e6b96-7291-4dea-9d0f-9a22066c5e9d.png)

after
![image](https://user-images.githubusercontent.com/44017204/125444017-fdee82d0-ab54-404a-9138-2cd2e4a89968.png)


### Usage

Edit->Tools Options->Decompiler->Analysis
You can see an option called **Short variable names**
![image](https://user-images.githubusercontent.com/44017204/125444164-24af4e26-f46e-4b6c-a016-569f87c8d216.png)
