### PR TITLE
fix open dir widge GUI problem

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/AbstractGCellRenderer.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/AbstractGCellRenderer.java
@@ -19,6 +19,7 @@ import java.awt.*;
 
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
+import javax.swing.UIManager;
 import javax.swing.border.Border;
 
 import docking.widgets.label.GDHtmlLabel;
@@ -156,7 +157,7 @@ public abstract class AbstractGCellRenderer extends GDHtmlLabel {
 	}
 
 	protected Color getDefaultBackgroundColor() {
-		return Color.WHITE;
+		return UIManager.getColor("Background");
 	}
 
 	protected Color getBackgroundColorForRow(int row) {

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/DirectoryList.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/DirectoryList.java
@@ -184,12 +184,10 @@ class DirectoryList extends GList<File> implements GhidraFileChooserDirectoryMod
 		});
 
 		listEditor = new JPanel(new BorderLayout());
-		listEditor.setBorder(BorderFactory.createLineBorder(Color.GRAY));
 
 		listEditor.add(listEditorLabel, BorderLayout.WEST);
 		listEditor.add(listEditorField, BorderLayout.CENTER);
 
-		listEditor.setBackground(Color.WHITE);
 		listEditorField.setBorder(BorderFactory.createEmptyBorder(2, 2, 2, 2));
 
 		add(listEditor);

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/FileChooserToggleButton.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/FileChooserToggleButton.java
@@ -29,15 +29,10 @@ import javax.swing.event.ChangeListener;
 public class FileChooserToggleButton extends JToggleButton {
 	private static final long serialVersionUID = 1L;
 
-    static final Border RAISED_BORDER = BorderFactory.createCompoundBorder(
-				BorderFactory.createRaisedBevelBorder(),
-				BorderFactory.createEmptyBorder(1,1,1,1));
 
-    static final Border NO_BORDER = new EmptyBorder(RAISED_BORDER.getBorderInsets(new JButton()));
-
-    static final Border LOWERED_BORDER = BorderFactory.createCompoundBorder(
-				BorderFactory.createLoweredBevelBorder(),
-				BorderFactory.createEmptyBorder(1,1,1,1));
+    static final Border NO_BORDER = BorderFactory.createEmptyBorder(1, 1, 1, 1);
+    static final Border RAISED_BORDER = NO_BORDER;
+    static final Border LOWERED_BORDER = NO_BORDER;
 
 	public FileChooserToggleButton(String text) {
 		super(text);
@@ -49,15 +44,26 @@ public class FileChooserToggleButton extends JToggleButton {
 		initBorder();
 	}
 
+	private void setFocusBackground() {
+		setBackground(new Color(87, 92, 95));
+	}
+
+	private void setPressBackground() {
+		setBackground(new Color(112, 117, 120));
+	}
+
+	private void clearBackground() {
+		setBackground(Color.DARK_GRAY);
+	}
+
 	private void initBorder() {
-		setForeground(Color.WHITE);
+		setContentAreaFilled(true);
 		setOpaque(true);		
 		setHorizontalTextPosition(SwingConstants.CENTER);
 		setVerticalTextPosition(SwingConstants.BOTTOM);
-		clearBorder();		
-		
-		// prevents the WinXP LNF from painting its awkward borders
-		setContentAreaFilled( false );
+		this.setBorder(new EmptyBorder(4, 4, 4, 4));
+		clearBackground();
+		clearBorder();
 		
 		// changes the border on hover and click
 		addMouseListener(new ButtonMouseListener());
@@ -66,10 +72,10 @@ public class FileChooserToggleButton extends JToggleButton {
 		addChangeListener( new ChangeListener() {
             public void stateChanged( ChangeEvent e ) {
                 if ( isSelected() ) {
-                    setBorder( LOWERED_BORDER );
+					setPressBackground();
                 }
                 else {                    
-                    setBorder( NO_BORDER );
+					clearBackground();
                 }
             }		    
 		} );
@@ -90,7 +96,7 @@ public class FileChooserToggleButton extends JToggleButton {
 		private boolean inside = false;
 
 		private Border defaultBorder;
-		
+
 		@Override
         public void mouseEntered(MouseEvent me)  {
 		    if ( isSelected() ) {
@@ -98,6 +104,7 @@ public class FileChooserToggleButton extends JToggleButton {
 		    }
 		    
 		    defaultBorder = getBorder();
+			setFocusBackground();
 			setBorder(RAISED_BORDER);
 			inside = true;
 		}
@@ -109,6 +116,7 @@ public class FileChooserToggleButton extends JToggleButton {
             }
 		    
 			inside = false;
+			clearBackground();
 			restoreBorder();
 		}
 
@@ -119,7 +127,7 @@ public class FileChooserToggleButton extends JToggleButton {
             }
 		    
 			if (e.getButton() == MouseEvent.BUTTON1) {
-				setBorder(LOWERED_BORDER);
+				setPressBackground();
 			}
 		}
 
@@ -128,6 +136,8 @@ public class FileChooserToggleButton extends JToggleButton {
 		    if ( isSelected() ) {
                 return;
             }
+
+			clearBackground();
 		    
 			if (inside) {
 				setBorder(RAISED_BORDER);

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/GhidraFileChooser.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/GhidraFileChooser.java
@@ -71,8 +71,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 		implements GhidraFileChooserListener, FileFilter {
 
 	static final String UP_BUTTON_NAME = "UP_BUTTON";
-	private static final Color FOREROUND_COLOR = Color.BLACK;
-	private static final Color BACKGROUND_COLOR = Color.WHITE;
 	static final String PREFERENCES_PREFIX = "G_FILE_CHOOSER";
 	private static final String WIDTH_PREFERENCE_PREFIX = PREFERENCES_PREFIX + ".WIDTH.";
 	private static final String HEIGHT_PREFERENCE_PREFIX = PREFERENCES_PREFIX + ".HEIGHT.";
@@ -307,7 +305,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 		myComputerButton.setName("MY_COMPUTER_BUTTON");
 		myComputerButton.setIcon(ResourceManager.loadImage("images/computer.png"));
 		myComputerButton.addActionListener(e -> updateMyComputer());
-		myComputerButton.setForeground(FOREROUND_COLOR);
 
 		desktopButton = new FileChooserToggleButton("Desktop") {
 			@Override
@@ -318,7 +315,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 		desktopButton.setName("DESKTOP_BUTTON");
 		desktopButton.setIcon(ResourceManager.loadImage("images/desktop.png"));
 		desktopButton.addActionListener(e -> updateDesktop());
-		desktopButton.setForeground(FOREROUND_COLOR);
 		desktopButton.setEnabled(fileChooserModel.getDesktopDirectory() != null);
 
 		homeButton = new FileChooserToggleButton("Home") {
@@ -330,7 +326,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 		homeButton.setName("HOME_BUTTON");
 		homeButton.setIcon(ResourceManager.loadImage("images/user-home.png"));
 		homeButton.addActionListener(e -> updateHome());
-		homeButton.setForeground(FOREROUND_COLOR);
 
 		recentButton = new FileChooserToggleButton("Recent") {
 			@Override
@@ -346,7 +341,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 
 		recentButton.setIcon(multiIcon);
 		recentButton.addActionListener(e -> updateRecent());
-		recentButton.setForeground(FOREROUND_COLOR);
 
 		shortCutButtonGroup = new UnselectableButtonGroup();
 		shortCutButtonGroup.add(myComputerButton);
@@ -362,8 +356,7 @@ public class GhidraFileChooser extends DialogComponentProvider
 		shortCutPanel.add(recentButton);
 
 		JPanel panel = new JPanel(new BorderLayout());
-		panel.setBorder(BorderFactory.createLoweredBevelBorder());
-		panel.setBackground(BACKGROUND_COLOR.darker());
+		//panel.setBorder(BorderFactory.createLoweredBevelBorder());
 		panel.add(shortCutPanel, BorderLayout.NORTH);
 		return panel;
 	}
@@ -471,7 +464,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 	private void buildWaitPanel() {
 		waitPanel = new JPanel(new BorderLayout());
 		waitPanel.setBorder(BorderFactory.createLoweredBevelBorder());
-		waitPanel.setBackground(BACKGROUND_COLOR);
 		waitPanel.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseReleased(MouseEvent e) {
@@ -575,7 +567,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 		directoryListModel = new DirectoryListModel();
 		directoryList = new DirectoryList(this, directoryListModel, rootPanel.getFont());
 		directoryList.setName("LIST");
-		directoryList.setBackground(BACKGROUND_COLOR);
 
 		directoryList.addFocusListener(new FocusAdapter() {
 			@Override
@@ -585,7 +576,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 		});
 
 		directoryScroll = new JScrollPane(directoryList);
-		directoryScroll.getViewport().setBackground(BACKGROUND_COLOR);
 		directoryScroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
 		directoryScroll.addComponentListener(new ComponentAdapter() {
 			//if the scroll pane is resized, we need to adjust
@@ -1471,7 +1461,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 		directoryTableModel = new DirectoryTableModel(this);
 		directoryTable = new DirectoryTable(this, directoryTableModel);
 		directoryTable.setName("TABLE");
-		directoryTable.setBackground(BACKGROUND_COLOR);
 
 		directoryTable.addFocusListener(new FocusAdapter() {
 			@Override
@@ -1481,7 +1470,6 @@ public class GhidraFileChooser extends DialogComponentProvider
 		});
 
 		JScrollPane scrollPane = new JScrollPane(directoryTable);
-		scrollPane.getViewport().setBackground(BACKGROUND_COLOR);
 		return scrollPane;
 	}
 


### PR DESCRIPTION
This PR should resolve the problems within open dir/file widget, including:

- the border style of the toggle button (i.e, "My Computer", "Recent", ...) are classical style with lowered border style.
- the explicitly set white background is mixed with the default white font color, which makes the text unable to read